### PR TITLE
Support for BoringSSL

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,15 @@
 CXXFLAGS+=-g -Wall -Werror -O2
 
-CPPFLAGS+=-I../openssl/include
-LDFLAGS+=-L../openssl
+ifeq (,$(BORINGSSL))
+  CPPFLAGS+=-I../openssl/include
+  LDFLAGS+=-L../openssl
+  ENV=env LD_LIBRARY_PATH=../openssl
+else
+  CPPFLAGS+=-I../boringssl/include -DBORINGSSL=1
+  LDFLAGS+=-L../boringssl
+  ENV=env LD_LIBRARY_PATH=../boringssl
+endif
 LDLIBS+=-lssl -lcrypto -ldl -lpthread
-ENV=env LD_LIBRARY_PATH=../openssl
 MEMUSAGE=/usr/bin/time -f %M
 
 bench: bench.cc

--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ The measured aspects are:
 
 The code expects a built OpenSSL tree in `../openssl/` and the rustls repository in `../rustls`.
 
+Optionally you may provide a BoringSSL tree in `../boringssl/`, and select it using `make ... BORINGSSL=1`
+
 ## Running
 
 - `make measure`: runs bulk transfer and handshake throughput benchmarks using a predefined list of


### PR DESCRIPTION
- refuse to test stateful resumption for TLS1.3
- work around missing client-side session store